### PR TITLE
Improve performance of variable renaming prompt.

### DIFF
--- a/degpt/prompt.json
+++ b/degpt/prompt.json
@@ -20,7 +20,7 @@
         "name": "rename_var",
         "prompt": {
             "role": "user",
-            "content": "Help me rename the variables for the code snippet in the following C code. Output the old name and its new name in a *single* JSON dictionary. For example, use {{\"old_name\": \"new_name\"}} to represent replace the variable name \"old_name\" with \"new_name\". No explanation. \\n {code}"
+            "content": "Help me rename the variables for the code snippet in the following C code. Output the old name and its new name in a *single* JSON dictionary. Do not use any markdown formatting. For example, use {{\"old_name\": \"new_name\"}} to represent replace the variable name \"old_name\" with \"new_name\". No explanation. \\n {code}"
         }
     },
     {

--- a/degpt/prompt.json
+++ b/degpt/prompt.json
@@ -20,7 +20,7 @@
         "name": "rename_var",
         "prompt": {
             "role": "user",
-            "content": "Help me rename the variables for the code snippet in the following C code. Output the old name and its new name in JSON structure. For example, use {{\"old_name\": \"new_name\"}} to represent replace the variable name \"old_name\" with \"new_name\". No explanation. \\n {code}"
+            "content": "Help me rename the variables for the code snippet in the following C code. Output the old name and its new name in a *single* JSON dictionary. For example, use {{\"old_name\": \"new_name\"}} to represent replace the variable name \"old_name\" with \"new_name\". No explanation. \\n {code}"
         }
     },
     {


### PR DESCRIPTION
With the original prompt, GPT was often returning a separate dict on each line, which failed to parse.