### PR TITLE
degpt/config.ini: add default value and comments for api_base

### DIFF
--- a/degpt/config.ini
+++ b/degpt/config.ini
@@ -1,4 +1,7 @@
 [LLM]
 model = gpt-3.5-turbo
 api_key =
-api_base =
+api_base = https://api.openai.com/v1/
+
+; For openai online LLMs, the default api_base is https://api.openai.com/v1/
+; For local LLMs, the api_base is usually like http://ip:port/v1/


### PR DESCRIPTION
The default api_base of openai models is https://api.openai.com/v1/. Add default value and comments for that.